### PR TITLE
Bump to GPJax v0.12.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+  name: Release
+
+  on:
+    push:
+      tags:
+        - "v*.*.*"
+
+  permissions:
+    contents: write
+
+  jobs:
+    release:
+      runs-on: ubuntu-latest
+      environment: pypi
+
+      permissions:
+        contents: write
+        id-token: write
+
+      steps:
+        - name: Check out source
+          uses: actions/checkout@v4
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version: "3.12"
+
+        - name: Install build and test tools
+          run: python -m pip install tox build
+
+        - name: Run tests
+          run: tox run
+
+        - name: Build distributions
+          run: python -m build
+
+        - name: Publish to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+
+        - name: Create GitHub Release
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            gh release create "$GITHUB_REF_NAME" dist/* \
+              --title "$GITHUB_REF_NAME" \
+              --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ kohgpjax.egg-info/
 coverage.xml
 
 environment.yml
+uv.lock
+
 *.npz
 *.npy
 

--- a/kohgpjax/__init__.py
+++ b/kohgpjax/__init__.py
@@ -9,7 +9,7 @@ __description__ = (
 )
 __url__ = "https://github.com/jamesbriant/KOH-GPJax"
 __contributors__ = "James Briant - https://james.briant.co.uk"
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = [
     "gps",

--- a/kohgpjax/kernels/computations/kohcomputation.py
+++ b/kohgpjax/kernels/computations/kohcomputation.py
@@ -62,6 +62,7 @@ class KOHKernelComputation(AbstractKernelComputation):
         a = kernel.num_field_obs
         b = kernel.num_sim_obs
         N = x.shape[0]
+        M = y.shape[0]
 
         # PART 1 & 2
         sigma_eta, sigma_delta, sigma_epsilon, sigma_epsilon_eta = (
@@ -71,5 +72,5 @@ class KOHKernelComputation(AbstractKernelComputation):
         # PART 3 - Construct the output array
         return sigma_eta + pad(
             block_diag(sigma_delta + sigma_epsilon, sigma_epsilon_eta),
-            ((0, N - a - b), (0, N - a - b)),
+            ((0, N - a - b), (0, M - a - b)),
         )

--- a/kohgpjax/kohmodel.py
+++ b/kohgpjax/kohmodel.py
@@ -194,10 +194,15 @@ class KOHModel(nnx.Module):
         # Gaussian() wraps scalar noise in GPJax's trainable NonNegativeReal.
         # KOH-GPJax puts observation noise in k_epsilon(), so the likelihood's
         # zero-noise placeholder must not be exposed to GPJax optimisers.
-        return gpx.likelihoods.Gaussian(
+        likelihood = gpx.likelihoods.Gaussian(
             num_datapoints=num_datapoints,
-            obs_stddev=nnx.Variable(jnp.asarray(0.0)),  # See self.k_epsilon()
+            obs_stddev=0.0,  # See self.k_epsilon()
         )
+        # Gaussian.__init__ wraps scalar values as NonNegativeReal parameters,
+        # so replace the zero-noise placeholder after construction with a
+        # non-trainable NNX variable.
+        likelihood.obs_stddev = nnx.Variable(jnp.asarray(0.0))
+        return likelihood
 
     def GP_posterior(
         self,

--- a/kohgpjax/kohmodel.py
+++ b/kohgpjax/kohmodel.py
@@ -29,7 +29,7 @@ class KOHModel(nnx.Module):
         self,
         model_parameters: MP,
         kohdataset: KOHDataset,
-        obs_stddev: gpx.parameters.Static = None,
+        obs_stddev=None,
         jitter: float = 1e-6,
     ):
         """
@@ -39,25 +39,32 @@ class KOHModel(nnx.Module):
             The model parameters for the KOH model.
         kohdataset: KOHDataset
             The dataset containing the field and simulation observations.
-        obs_stddev: gpx.parameters.Static
-            The standard deviation of the observations. If not None, it will be static and not estimated.
+        obs_stddev: scalar or one-element array, optional
+            The standard deviation of the observations. If supplied, it is fixed
+            for this KOH model rather than read from ``params_constrained``.
         jitter: float
             The jitter to add to the covariance matrix for numerical stability.
         """
         if obs_stddev is not None:
-            if not isinstance(obs_stddev, gpx.parameters.Static):
+            try:
+                obs_stddev = jnp.asarray(obs_stddev)
+            except (TypeError, ValueError) as exc:
                 raise ValueError(
-                    "`obs_stddev` must be a `gpx.parameters.Static` object or `None`."
+                    "`obs_stddev` must be a non-negative scalar or one-element array."
+                ) from exc
+
+            if obs_stddev.ndim > 1 or obs_stddev.size != 1:
+                raise ValueError(
+                    "`obs_stddev` must be a non-negative scalar or one-element array."
                 )
-            # if obs_stddev.shape != (1,): #TODO: This should be changed to allow a vector of variances
-            #     raise ValueError("`obs_stddev` must have shape `(1,)`. For more complex models, implement your own `k_epsilon()` method.")
+            if not bool(jnp.all(obs_stddev >= 0)):
+                raise ValueError("`obs_stddev` must be non-negative.")
+
             self.obs_stddev = obs_stddev
 
         self.model_parameters = model_parameters
         self.kohdataset = kohdataset
-        self.obs_var = (
-            gpx.parameters.Static(obs_stddev**2) if obs_stddev is not None else None
-        )
+        self.obs_var = obs_stddev**2 if obs_stddev is not None else None
         self.jitter = jitter  # GPJax default is 1e-6
 
     ############## GPJAX MODEL ##############
@@ -129,13 +136,39 @@ class KOHModel(nnx.Module):
                     "k_epsilon: variance is None from both self.obs_var and params_constrained."
                 )
 
+        # GPJax wraps raw White-kernel variances in a trainable Parameter. Use a
+        # plain NNX Variable for explicitly fixed observation noise so it remains
+        # part of the kernel state without being selected by GPJax optimisers.
+        if self.obs_var is not None:
+            variance_to_use = nnx.Variable(variance_to_use)
+
         return gpx.kernels.White(
             active_dims=list(range(self.kohdataset.num_variable_params)),
             variance=variance_to_use,
         )
 
     def k_epsilon_eta(self, params_constrained) -> gpx.kernels.AbstractKernel:
-        return gpx.kernels.White(variance=0.0)
+        # This component is structurally zero by default. If the user supplies
+        # an epsilon_eta variance in the constrained parameter tree, pass the
+        # raw value to GPJax so it becomes an optimisable Parameter instead.
+        variance = (
+            params_constrained.get("epsilon_eta", {})
+            .get("variances", {})
+            .get("obs_noise")
+        )
+        if variance is None:
+            variance = (
+                params_constrained.get("epsilon_eta", {})
+                .get("variances", {})
+                .get("var")
+            )
+
+        if variance is None:
+            # A plain NNX Variable is retained by the kernel but excluded from
+            # GPJax's default Parameter trainable filter.
+            variance = nnx.Variable(jnp.asarray(0.0))
+
+        return gpx.kernels.White(variance=variance)
 
     def GP_kernel(self, GPJAX_params: ModelParameterDict) -> gpx.kernels.AbstractKernel:
         return KOHKernel(
@@ -158,9 +191,12 @@ class KOHModel(nnx.Module):
         Returns:
             A GPJAX likelihood object.
         """
+        # Gaussian() wraps scalar noise in GPJax's trainable NonNegativeReal.
+        # KOH-GPJax puts observation noise in k_epsilon(), so the likelihood's
+        # zero-noise placeholder must not be exposed to GPJax optimisers.
         return gpx.likelihoods.Gaussian(
             num_datapoints=num_datapoints,
-            obs_stddev=0.0,  # See self.k_epsilon()
+            obs_stddev=nnx.Variable(jnp.asarray(0.0)),  # See self.k_epsilon()
         )
 
     def GP_posterior(

--- a/kohgpjax/parameters.py
+++ b/kohgpjax/parameters.py
@@ -147,6 +147,7 @@ class ModelParameters:
         Returns:
             A list of samples transformed to the constrained space.
         """
+        _check_sample_length(samples_flat, self.n_params)
         return [
             prior.forward(samples_flat[i]) for i, prior in enumerate(self.priors_flat)
         ]
@@ -162,6 +163,7 @@ class ModelParameters:
         Returns:
             A tree of samples with the same structure as the priors.
         """
+        _check_sample_length(samples_flat, self.n_params)
         # Unflatten the samples to the original tree structure
         return jax.tree.unflatten(self.priors_tree, samples_flat)
 
@@ -240,6 +242,11 @@ def _check_prior_dict(prior_dict: ModelParameterPriorDict) -> None:
                     )
 
         else:
+            if not isinstance(param_prior_dict, dict):
+                raise ValueError(
+                    f"prior_dict['{key}'] must be a dictionary of parameter groups."
+                )
+
             if "variances" not in param_prior_dict:
                 raise KeyError(
                     f"prior_dict key '{key}' must contain 'variances' key with dictionary of ParameterPrior instances."
@@ -261,3 +268,20 @@ def _check_prior_dict(prior_dict: ModelParameterPriorDict) -> None:
         # e.g. if kernel_item['kernel'] is RBF, check that lengthscale is a npd.Distribution
         # How to get the parameters from the kernel class?
         # Is this worth the faff?
+
+
+def _check_sample_length(samples_flat, expected_length: int) -> None:
+    """Check that a flat sample contains exactly one value per prior."""
+    try:
+        actual_length = len(samples_flat)
+    except TypeError as error:
+        raise ValueError(
+            "Flat samples must be a one-dimensional sequence with "
+            f"{expected_length} values."
+        ) from error
+
+    if actual_length != expected_length:
+        raise ValueError(
+            f"Flat samples must contain exactly {expected_length} values. "
+            f"Got {actual_length}."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,10 @@ dependencies = [
   "beartype",
   "cola-ml",
   "flax",
-  "gpjax>0.11.0,<=0.12.0",
-  "jax<0.7",
+  "gpjax>0.11.0,<=0.12.2",
+  "jax>=0.5.0,<0.7",
+  "jaxlib>=0.5.0,<0.7",
+  "numpy>=2.0",
   "jaxtyping",
   "numpyro",
 ]

--- a/tests/kernels/test_kohcomputation.py
+++ b/tests/kernels/test_kohcomputation.py
@@ -186,17 +186,17 @@ def test_kohkernelcomputation_cross_covariance_values(setup_computation_test):
     actual_gram_matrix_jit = to_dense_if_needed(actual_gram_matrix_jit_op)
     assert jnp.allclose(actual_gram_matrix_jit, expected_gram_matrix, atol=1e-6)
 
-    # Test the N != M case for cross_covariance, expecting a broadcasting error
-    # due to the current padding logic in the source code.
+    # Rectangular cross-covariance must be supported. The eta component is
+    # rectangular, while the structured correction is padded independently in
+    # the row and column dimensions.
     X_generic1 = s["X1"]
-    # Re-create an X_generic2 that has M != N for this specific check, as fixture X2 might now have M=N
     n_field_obs_s, _, dim_k_eta_inputs_s = (
         s["n_field_obs"],
         kernel.num_sim_obs,
         X_generic1.shape[1],
     )
     N_current = X_generic1.shape[0]
-    M_for_error_check = N_current + 1  # Ensure M != N
+    M_for_rectangular_check = N_current + 1
 
     X2_field_err = (
         jnp.arange(n_field_obs_s * dim_k_eta_inputs_s).reshape(
@@ -205,18 +205,43 @@ def test_kohkernelcomputation_cross_covariance_values(setup_computation_test):
         * 0.7
     ) + 0.01
     X2_sim_err = (
-        jnp.arange((M_for_error_check - n_field_obs_s) * dim_k_eta_inputs_s).reshape(
-            (M_for_error_check - n_field_obs_s), dim_k_eta_inputs_s
-        )
+        jnp.arange(
+            (M_for_rectangular_check - n_field_obs_s) * dim_k_eta_inputs_s
+        ).reshape((M_for_rectangular_check - n_field_obs_s), dim_k_eta_inputs_s)
         * 0.8
     ) + 0.01
-    X_generic2_for_error_check = jnp.vstack((X2_field_err, X2_sim_err))
+    X_generic2_rectangular = jnp.vstack((X2_field_err, X2_sim_err))
 
-    if X_generic1.shape[0] != X_generic2_for_error_check.shape[0]:
-        with pytest.raises(TypeError, match="incompatible shapes for broadcasting"):
-            # This call is expected to fail due to the padding issue when N != M
-            # and the subsequent addition sigma_eta + padded_block_diag
-            engine.cross_covariance(kernel, X_generic1, X_generic2_for_error_check)
+    rectangular = engine.cross_covariance(kernel, X_generic1, X_generic2_rectangular)
+    assert rectangular.shape == (
+        X_generic1.shape[0],
+        X_generic2_rectangular.shape[0],
+    )
 
-
-# End of test_kohcomputation.py
+    sigma_eta_rectangular = kernel.k_eta.cross_covariance(
+        X_generic1, X_generic2_rectangular
+    )
+    sigma_delta_rectangular = kernel.k_delta.cross_covariance(
+        X_generic1[:n_field_obs_s], X_generic2_rectangular[:n_field_obs_s]
+    )
+    sigma_epsilon_rectangular = kernel.k_epsilon.cross_covariance(
+        X_generic1[:n_field_obs_s], X_generic2_rectangular[:n_field_obs_s]
+    )
+    sigma_epsilon_eta_rectangular = kernel.k_epsilon_eta.cross_covariance(
+        X_generic1[n_field_obs_s : n_field_obs_s + kernel.num_sim_obs],
+        X_generic2_rectangular[n_field_obs_s : n_field_obs_s + kernel.num_sim_obs],
+    )
+    expected_rectangular = sigma_eta_rectangular + jnp.pad(
+        block_diag(
+            sigma_delta_rectangular + sigma_epsilon_rectangular,
+            sigma_epsilon_eta_rectangular,
+        ),
+        (
+            (0, X_generic1.shape[0] - n_field_obs_s - kernel.num_sim_obs),
+            (
+                0,
+                X_generic2_rectangular.shape[0] - n_field_obs_s - kernel.num_sim_obs,
+            ),
+        ),
+    )
+    assert jnp.allclose(rectangular, expected_rectangular, atol=1e-6)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,23 +1,29 @@
 import pytest
 from gpjax.dataset import Dataset
-from jax import numpy as jnp  # Removed 'config'
+from jax import config
+from jax import numpy as jnp
+from jax import tree_util as jtu
 from kohgpjax.dataset import KOHDataset
+
+config.update("jax_enable_x64", True)
 
 # --- Fixtures ---
 
 
 @pytest.fixture(scope="module")
 def field_data_input():
-    x_field = jnp.array([[1.0, 2.0], [3.0, 4.0]])
-    y_field = jnp.array([[1.0], [2.0]])
+    x_field = jnp.array([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.float64)
+    y_field = jnp.array([[1.0], [2.0]], dtype=jnp.float64)
     return Dataset(x_field, y_field)
 
 
 @pytest.fixture(scope="module")
 def sim_data_input():
     # x_sim has 2 variable params and 2 calibration params
-    x_sim = jnp.array([[1.0, 2.0, 3.0, 2.0], [4.0, 5.0, 6.0, 3.0]])
-    y_sim = jnp.array([[1.0], [2.0]])
+    x_sim = jnp.array(
+        [[1.0, 2.0, 3.0, 2.0], [4.0, 5.0, 6.0, 3.0]], dtype=jnp.float64
+    )
+    y_sim = jnp.array([[1.0], [2.0]], dtype=jnp.float64)
     return Dataset(x_sim, y_sim)
 
 
@@ -292,3 +298,117 @@ def test_koh_dataset_tree_flatten_unflatten(
         new_instance.num_calib_params == koh_dataset_instance.num_calib_params
     )  # Check one derived attribute
     assert jnp.array_equal(new_instance.d, koh_dataset_instance.d)  # Check a property
+
+
+@pytest.mark.parametrize(("x_rows", "y_rows"), [(2, 1), (1, 2)])
+def test_koh_dataset_rejects_mismatched_input_and_output_rows(x_rows, y_rows):
+    """GPJax rejects each dataset before it can form a KOHDataset."""
+    X = jnp.ones((x_rows, 1), dtype=jnp.float64)
+    y = jnp.ones((y_rows, 1), dtype=jnp.float64)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Inputs, X, and outputs, y, must have the same number of rows",
+    ):
+        Dataset(X, y)
+
+
+def test_koh_dataset_rejects_zero_calibration_parameters():
+    field_dataset = Dataset(
+        jnp.ones((2, 1), dtype=jnp.float64),
+        jnp.ones((2, 1), dtype=jnp.float64),
+    )
+    simulation_dataset = Dataset(
+        jnp.ones((3, 1), dtype=jnp.float64),
+        jnp.ones((3, 1), dtype=jnp.float64),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Input dimension of simulation data \(1\) must be greater than input dimension of field data \(1\)",
+    ):
+        KOHDataset(field_dataset, simulation_dataset)
+
+
+def test_koh_dataset_supports_one_calibration_parameter():
+    field_dataset = Dataset(
+        jnp.array([[1.0], [2.0]], dtype=jnp.float64),
+        jnp.array([[10.0], [20.0]], dtype=jnp.float64),
+    )
+    simulation_dataset = Dataset(
+        jnp.array([[1.0, 0.1], [2.0, 0.2], [3.0, 0.3]], dtype=jnp.float64),
+        jnp.array([[11.0], [22.0], [33.0]], dtype=jnp.float64),
+    )
+    koh_dataset = KOHDataset(field_dataset, simulation_dataset)
+
+    assert koh_dataset.num_calib_params == 1
+    theta = jnp.array([[0.75]], dtype=jnp.float64)
+    assert jnp.array_equal(
+        koh_dataset.X(theta),
+        jnp.array(
+            [[1.0, 0.75], [2.0, 0.75], [1.0, 0.1], [2.0, 0.2], [3.0, 0.3]],
+            dtype=jnp.float64,
+        ),
+    )
+
+
+@pytest.mark.parametrize(("num_field_obs", "num_sim_obs"), [(1, 1), (3, 2), (2, 5)])
+def test_koh_dataset_supports_multiple_field_and_simulation_counts(
+    num_field_obs, num_sim_obs
+):
+    field_dataset = Dataset(
+        jnp.arange(num_field_obs, dtype=jnp.float64).reshape(-1, 1),
+        jnp.arange(num_field_obs, dtype=jnp.float64).reshape(-1, 1),
+    )
+    simulation_dataset = Dataset(
+        jnp.arange(num_sim_obs * 2, dtype=jnp.float64).reshape(num_sim_obs, 2),
+        jnp.arange(num_sim_obs, dtype=jnp.float64).reshape(-1, 1),
+    )
+    koh_dataset = KOHDataset(field_dataset, simulation_dataset)
+    theta = jnp.array([[5.0]], dtype=jnp.float64)
+
+    assert koh_dataset.num_field_obs == num_field_obs
+    assert koh_dataset.num_sim_obs == num_sim_obs
+    assert koh_dataset.n == num_field_obs + num_sim_obs
+    assert koh_dataset.X(theta).shape == (num_field_obs + num_sim_obs, 2)
+    assert koh_dataset.d.shape == (num_field_obs + num_sim_obs, 1)
+    assert jnp.all(koh_dataset.Xf_theta(theta)[:, 1] == 5.0)
+
+
+def test_koh_dataset_preserves_float64_dtype_through_functional_operations():
+    dtype = jnp.float64
+    field_dataset = Dataset(
+        jnp.array([[1.0], [2.0]], dtype=dtype),
+        jnp.array([[10.0], [20.0]], dtype=dtype),
+    )
+    simulation_dataset = Dataset(
+        jnp.array([[1.0, 0.1], [2.0, 0.2]], dtype=dtype),
+        jnp.array([[11.0], [22.0]], dtype=dtype),
+    )
+    koh_dataset = KOHDataset(field_dataset, simulation_dataset)
+    theta = jnp.array([[0.5]], dtype=dtype)
+
+    assert koh_dataset.Xf.dtype == dtype
+    assert koh_dataset.Xc.dtype == dtype
+    assert koh_dataset.z.dtype == dtype
+    assert koh_dataset.y.dtype == dtype
+    assert koh_dataset.d.dtype == dtype
+    assert koh_dataset.Xf_theta(theta).dtype == dtype
+    assert koh_dataset.X(theta).dtype == dtype
+    assert koh_dataset.get_dataset(theta).X.dtype == dtype
+    assert koh_dataset.get_dataset(theta).y.dtype == dtype
+
+
+def test_koh_dataset_pytree_round_trip_remains_functionally_usable(
+    koh_dataset_instance,
+):
+    leaves, treedef = jtu.tree_flatten(koh_dataset_instance)
+    reconstructed = jtu.tree_unflatten(treedef, leaves)
+    theta = jnp.array([[1.5, 2.5]])
+
+    assert jnp.array_equal(reconstructed.X(theta), koh_dataset_instance.X(theta))
+    assert jnp.array_equal(reconstructed.d, koh_dataset_instance.d)
+    reconstructed_dataset = reconstructed.get_dataset(theta)
+    original_dataset = koh_dataset_instance.get_dataset(theta)
+    assert jnp.array_equal(reconstructed_dataset.X, original_dataset.X)
+    assert jnp.array_equal(reconstructed_dataset.y, original_dataset.y)

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -177,6 +177,17 @@ def test_koh_posterior_predict_zeta_type(
         test_input_points_fixture.shape[0],
     )
 
+    # Adding observation noise must add precisely the epsilon kernel's
+    # covariance to the latent zeta predictive covariance.
+    expected_noise = mock_prior_fixture.kernel.k_epsilon.cross_covariance(
+        test_input_points_fixture, test_input_points_fixture
+    )
+    assert jnp.allclose(
+        prediction_true.covariance() - prediction_false.covariance(),
+        expected_noise,
+        atol=1e-5,
+    )
+
     # Check JIT compilability
     # JIT with static include_observation_noise works for both False and True
     jitted_predict_zeta_static = jit(
@@ -213,6 +224,63 @@ def test_koh_posterior_predict_obs_type(
     assert prediction.covariance().shape == (
         test_input_points_fixture.shape[0],
         test_input_points_fixture.shape[0],
+    )
+
+
+def test_koh_posterior_predict_delta_has_delta_only_prior_covariance(
+    mock_prior_fixture: gpx.gps.Prior,
+    mock_likelihood_fixture: gpx.likelihoods.Gaussian,
+    test_input_points_fixture: jnp.ndarray,
+    mock_dataset_fixture: Dataset,
+):
+    posterior = construct_posterior(mock_prior_fixture, mock_likelihood_fixture)
+    prediction = posterior.predict_delta(
+        test_input_points_fixture, train_data=mock_dataset_fixture
+    )
+
+    assert isinstance(prediction, GaussianDistribution)
+    assert prediction.mean.shape == (test_input_points_fixture.shape[0],)
+    assert prediction.covariance().shape == (
+        test_input_points_fixture.shape[0],
+        test_input_points_fixture.shape[0],
+    )
+    assert jnp.allclose(
+        prediction.covariance(), prediction.covariance().T, atol=1e-6
+    )
+    assert jnp.all(jnp.linalg.eigvalsh(prediction.covariance()) >= -1e-5)
+
+    # Independently reproduce the Gaussian conditioning calculation. The
+    # cross-covariance for delta is non-zero only for field observations.
+    x, y = mock_dataset_fixture.X, mock_dataset_fixture.y
+    num_field_obs = mock_prior_fixture.kernel.num_field_obs
+    kxx = mock_prior_fixture.kernel.cross_covariance(x, x)
+    kxt = jnp.pad(
+        mock_prior_fixture.kernel.k_delta.cross_covariance(
+            x[:num_field_obs], test_input_points_fixture
+        ),
+        ((0, x.shape[0] - num_field_obs), (0, 0)),
+    )
+    ktt = mock_prior_fixture.kernel.k_delta.cross_covariance(
+        test_input_points_fixture, test_input_points_fixture
+    )
+    obs_var = mock_likelihood_fixture.obs_stddev.value**2
+    kxx = kxx + jnp.diag(
+        jnp.pad(
+            jnp.ones(num_field_obs) * obs_var,
+            (0, x.shape[0] - num_field_obs),
+        )
+    )
+    kxx = kxx + jnp.eye(x.shape[0]) * posterior.prior.jitter
+    solved_kxt = jnp.linalg.solve(kxx, kxt)
+    expected_mean = solved_kxt.T @ y
+    expected_covariance = ktt - kxt.T @ solved_kxt
+    expected_covariance = expected_covariance + jnp.eye(
+        test_input_points_fixture.shape[0]
+    ) * posterior.prior.jitter
+
+    assert jnp.allclose(prediction.mean, expected_mean.squeeze(), atol=1e-5)
+    assert jnp.allclose(
+        prediction.covariance(), expected_covariance, atol=1e-5
     )
 
 

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -2,7 +2,6 @@ import gpjax as gpx
 import pytest
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
-from gpjax.parameters import Static
 from jax import jit  # Removed 'config'
 from jax import numpy as jnp
 from jax import tree_util as jtu
@@ -46,9 +45,7 @@ def mock_standard_prior_fixture() -> gpx.gps.Prior:  # For testing non-KOH path
 @pytest.fixture(scope="module")
 def mock_likelihood_fixture() -> gpx.likelihoods.Gaussian:
     # num_datapoints should match dataset used for predictions
-    return gpx.likelihoods.Gaussian(
-        num_datapoints=Static(jnp.array(4))
-    )  # Example: 2 field + 2 sim
+    return gpx.likelihoods.Gaussian(num_datapoints=4)  # Example: 2 field + 2 sim
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_kohmodel.py
+++ b/tests/test_kohmodel.py
@@ -325,11 +325,16 @@ def test_fixed_observation_noise_is_jittable(
 def test_kohmodel_subclasses_must_implement_both_component_kernels(
     model_class, missing_method
 ):
-    with pytest.raises(
-        TypeError,
-        match=rf"Can't instantiate abstract class {model_class.__name__} without an implementation for abstract method '{missing_method}'",
-    ):
+    with pytest.raises(TypeError) as exc_info:
         model_class(None, None)
+
+    # CPython formats this message differently across supported Python
+    # versions (for example, "with abstract method" versus "without an
+    # implementation for abstract method"). Check the stable information
+    # instead of depending on the exact wording.
+    message = str(exc_info.value)
+    assert model_class.__name__ in message
+    assert missing_method in message
 
 
 def test_gp_kernel(

--- a/tests/test_kohmodel.py
+++ b/tests/test_kohmodel.py
@@ -3,6 +3,7 @@ import numpyro.distributions as npd
 import pytest
 from gpjax.dataset import Dataset  # Corrected import
 from gpjax.parameters import Static  # Explicit import for Static
+from jax import config
 from jax import (  # Removed 'config'
     jit,
 )
@@ -19,6 +20,8 @@ from kohgpjax.parameters import (
     ModelParameters,
     ParameterPrior,
 )
+
+config.update("jax_enable_x64", True)
 
 # --- Minimal Concrete KOHModel Subclass ---
 
@@ -46,6 +49,16 @@ class MinimalKOHModel(KOHModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._kohdataset_cached_for_test = kwargs.get("kohdataset")
+
+
+class MissingEtaKOHModel(KOHModel):
+    def k_delta(self, params_constrained: dict) -> gpx.kernels.AbstractKernel:
+        return gpx.kernels.RBF()
+
+
+class MissingDeltaKOHModel(KOHModel):
+    def k_eta(self, params_constrained: dict) -> gpx.kernels.AbstractKernel:
+        return gpx.kernels.RBF()
 
 
 # --- Fixtures ---
@@ -202,6 +215,80 @@ def test_k_epsilon(
     assert k_eps_static.active_dims == list(
         range(koh_dataset_fixture.num_variable_params)
     )
+
+
+@pytest.mark.parametrize("invalid_obs_stddev", [0.1, jnp.array([0.1]), object()])
+def test_kohmodel_rejects_invalid_obs_stddev_types(
+    model_parameters_fixture: ModelParameters,
+    koh_dataset_fixture: KOHDataset,
+    invalid_obs_stddev,
+):
+    with pytest.raises(
+        ValueError,
+        match=r"`obs_stddev` must be a `gpx\.parameters\.Static` object or `None`\.",
+    ):
+        MinimalKOHModel(
+            model_parameters=model_parameters_fixture,
+            kohdataset=koh_dataset_fixture,
+            obs_stddev=invalid_obs_stddev,
+        )
+
+
+def test_k_epsilon_requires_dynamic_variance(
+    minimal_koh_model_fixture: MinimalKOHModel,
+):
+    with pytest.raises(
+        ValueError,
+        match=r"k_epsilon: variance is None from both self\.obs_var and params_constrained\.",
+    ):
+        minimal_koh_model_fixture.k_epsilon({})
+
+
+def test_static_and_learned_observation_noise_have_distinct_numeric_covariances(
+    minimal_koh_model_fixture: MinimalKOHModel,
+    minimal_koh_model_static_obs_fixture: MinimalKOHModel,
+    gpjax_params_fixture: ModelParameterDict,
+    koh_dataset_fixture: KOHDataset,
+):
+    learned_params = {
+        **gpjax_params_fixture,
+        "epsilon": {
+            **gpjax_params_fixture["epsilon"],
+            "variances": {"obs_noise": jnp.array(0.25)},
+        },
+    }
+    learned_kernel = minimal_koh_model_fixture.k_epsilon(learned_params)
+    static_kernel = minimal_koh_model_static_obs_fixture.k_epsilon(
+        gpjax_params_fixture
+    )
+
+    learned_covariance = learned_kernel.cross_covariance(
+        koh_dataset_fixture.Xf, koh_dataset_fixture.Xf
+    )
+    static_covariance = static_kernel.cross_covariance(
+        koh_dataset_fixture.Xf, koh_dataset_fixture.Xf
+    )
+
+    assert jnp.allclose(learned_covariance, jnp.eye(koh_dataset_fixture.num_field_obs) * 0.25)
+    assert jnp.allclose(static_covariance, jnp.eye(koh_dataset_fixture.num_field_obs) * 0.01)
+    assert not jnp.allclose(learned_covariance, static_covariance)
+
+
+@pytest.mark.parametrize(
+    ("model_class", "missing_method"),
+    [
+        (MissingEtaKOHModel, "k_eta"),
+        (MissingDeltaKOHModel, "k_delta"),
+    ],
+)
+def test_kohmodel_subclasses_must_implement_both_component_kernels(
+    model_class, missing_method
+):
+    with pytest.raises(
+        TypeError,
+        match=rf"Can't instantiate abstract class {model_class.__name__} without an implementation for abstract method '{missing_method}'",
+    ):
+        model_class(None, None)
 
 
 def test_gp_kernel(

--- a/tests/test_kohmodel.py
+++ b/tests/test_kohmodel.py
@@ -277,6 +277,44 @@ def test_static_and_learned_observation_noise_have_distinct_numeric_covariances(
     assert not jnp.allclose(learned_covariance, static_covariance)
 
 
+def test_fixed_observation_noise_is_independent_of_model_parameters(
+    minimal_koh_model_static_obs_fixture: MinimalKOHModel,
+    gpjax_params_fixture: ModelParameterDict,
+    koh_dataset_fixture: KOHDataset,
+):
+    changed_params = {
+        **gpjax_params_fixture,
+        "epsilon": {
+            **gpjax_params_fixture["epsilon"],
+            "variances": {"obs_noise": jnp.array(100.0)},
+        },
+    }
+    X = koh_dataset_fixture.Xf
+
+    fixed_covariance = minimal_koh_model_static_obs_fixture.k_epsilon(
+        gpjax_params_fixture
+    ).cross_covariance(X, X)
+    changed_covariance = minimal_koh_model_static_obs_fixture.k_epsilon(
+        changed_params
+    ).cross_covariance(X, X)
+
+    assert jnp.allclose(fixed_covariance, changed_covariance)
+
+
+def test_fixed_observation_noise_is_jittable(
+    minimal_koh_model_static_obs_fixture: MinimalKOHModel,
+    gpjax_params_fixture: ModelParameterDict,
+    koh_dataset_fixture: KOHDataset,
+):
+    X = koh_dataset_fixture.Xf
+
+    kernel = minimal_koh_model_static_obs_fixture.k_epsilon(gpjax_params_fixture)
+    expected = kernel.cross_covariance(X, X)
+    actual = jit(lambda x: kernel.cross_covariance(x, x))(X)
+
+    assert jnp.allclose(actual, expected)
+
+
 @pytest.mark.parametrize(
     ("model_class", "missing_method"),
     [
@@ -313,6 +351,39 @@ def test_gp_kernel(
     assert jnp.isclose(
         kernel.k_epsilon_eta.variance.value, 0.0
     )  # k_epsilon_eta is White(0.0)
+    assert not isinstance(kernel.k_epsilon_eta.variance, Parameter)
+
+
+def test_epsilon_eta_can_be_enabled_as_a_trainable_nonzero_parameter(
+    minimal_koh_model_fixture: MinimalKOHModel,
+    gpjax_params_fixture: ModelParameterDict,
+):
+    params_with_epsilon_eta = {
+        **gpjax_params_fixture,
+        "epsilon_eta": {"variances": {"obs_noise": jnp.array(0.25)}},
+    }
+
+    kernel = minimal_koh_model_fixture.GP_kernel(params_with_epsilon_eta)
+
+    assert jnp.isclose(kernel.k_epsilon_eta.variance.value, 0.25)
+    assert isinstance(kernel.k_epsilon_eta.variance, Parameter)
+
+
+def test_enabled_epsilon_eta_is_included_in_gpjax_trainable_state(
+    minimal_koh_model_fixture: MinimalKOHModel,
+    gpjax_params_fixture: ModelParameterDict,
+):
+    params_with_epsilon_eta = {
+        **gpjax_params_fixture,
+        "epsilon_eta": {"variances": {"obs_noise": jnp.array(0.25)}},
+    }
+    posterior = minimal_koh_model_fixture.GP_posterior(params_with_epsilon_eta)
+    _, trainable_state, *_ = nnx.split(posterior, Parameter, ...)
+    trainable_paths = {path for path, _ in trainable_state.flat_state()}
+
+    assert any(
+        path[-2:] == ("k_epsilon_eta", "variance") for path in trainable_paths
+    )
 
 
 def test_likelihood(
@@ -328,6 +399,7 @@ def test_likelihood(
     assert likelihood.num_datapoints == num_total_obs
     # obs_stddev is 0.0 because variance is handled in k_epsilon
     assert jnp.isclose(likelihood.obs_stddev.value, 0.0)
+    assert not isinstance(likelihood.obs_stddev, Parameter)
 
 
 def test_gp_prior(
@@ -358,6 +430,64 @@ def test_gp_posterior(
     assert isinstance(posterior.likelihood, gpx.likelihoods.Gaussian)
     # Check if the kernel within the prior is a KOHKernel
     assert isinstance(posterior.prior.kernel, KOHKernel)
+
+
+def test_fixed_observation_noise_is_excluded_from_gpjax_trainable_state(
+    minimal_koh_model_static_obs_fixture: MinimalKOHModel,
+    gpjax_params_fixture: ModelParameterDict,
+):
+    posterior = minimal_koh_model_static_obs_fixture.GP_posterior(
+        gpjax_params_fixture
+    )
+    _, trainable_state, *_ = nnx.split(posterior, Parameter, ...)
+    trainable_paths = {path for path, _ in trainable_state.flat_state()}
+
+    assert not any(
+        path[-2:] == ("k_epsilon", "variance") for path in trainable_paths
+    )
+    assert not any(
+        path[-2:] == ("k_epsilon_eta", "variance") for path in trainable_paths
+    )
+    assert not any(path[-2:] == ("likelihood", "obs_stddev") for path in trainable_paths)
+
+    # Other model hyperparameters remain trainable.
+    assert any(path[-2:] == ("k_eta", "lengthscale") for path in trainable_paths)
+
+
+def test_learned_observation_noise_is_included_in_gpjax_trainable_state(
+    minimal_koh_model_fixture: MinimalKOHModel,
+    gpjax_params_fixture: ModelParameterDict,
+):
+    posterior = minimal_koh_model_fixture.GP_posterior(gpjax_params_fixture)
+    _, trainable_state, *_ = nnx.split(posterior, Parameter, ...)
+    trainable_paths = {path for path, _ in trainable_state.flat_state()}
+
+    assert any(
+        path[-2:] == ("k_epsilon", "variance") for path in trainable_paths
+    )
+
+
+def test_gpjax_fit_scipy_keeps_fixed_observation_noise_fixed(
+    minimal_koh_model_static_obs_fixture: MinimalKOHModel,
+    gpjax_params_fixture: ModelParameterDict,
+    koh_dataset_fixture: KOHDataset,
+):
+    posterior = minimal_koh_model_static_obs_fixture.GP_posterior(
+        gpjax_params_fixture
+    )
+    train_data = koh_dataset_fixture.get_dataset(jnp.array([[0.0]]))
+    initial_fixed_variance = posterior.prior.kernel.k_epsilon.variance.value
+
+    fitted_posterior, _ = gpx.fit_scipy(
+        model=posterior,
+        objective=lambda model, data: -gpx.objectives.conjugate_mll(model, data),
+        train_data=train_data,
+        max_iters=2,
+        verbose=False,
+    )
+
+    fitted_fixed_variance = fitted_posterior.prior.kernel.k_epsilon.variance.value
+    assert jnp.array_equal(fitted_fixed_variance, initial_fixed_variance)
 
 
 def test_get_koh_neg_log_pos_dens_func(

--- a/tests/test_kohmodel.py
+++ b/tests/test_kohmodel.py
@@ -1,8 +1,9 @@
 import gpjax as gpx  # Using gpx alias for gpjax
 import numpyro.distributions as npd
 import pytest
+from flax import nnx
 from gpjax.dataset import Dataset  # Corrected import
-from gpjax.parameters import Static  # Explicit import for Static
+from gpjax.parameters import Parameter
 from jax import config
 from jax import (  # Removed 'config'
     jit,
@@ -156,7 +157,7 @@ def minimal_koh_model_static_obs_fixture(
     return MinimalKOHModel(
         model_parameters=model_parameters_fixture,
         kohdataset=koh_dataset_fixture,
-        obs_stddev=Static(jnp.array([0.1])),  # static obs_stddev
+        obs_stddev=jnp.array([0.1]),  # fixed obs_stddev
         jitter=1e-6,
     )
 
@@ -178,10 +179,9 @@ def test_kohmodel_initialization(
     model_static = MinimalKOHModel(
         model_parameters_fixture,
         koh_dataset_fixture,
-        obs_stddev=Static(jnp.array([0.5])),
+        obs_stddev=jnp.array([0.5]),
     )
-    assert isinstance(model_static.obs_var, Static)
-    assert jnp.isclose(model_static.obs_var.value, 0.5**2)
+    assert jnp.isclose(model_static.obs_var, 0.5**2)
 
 
 def test_gp_prior_mean_function(minimal_koh_model_fixture: MinimalKOHModel):
@@ -203,6 +203,7 @@ def test_k_epsilon(
     # which is npd.HalfNormal(1.0).log_prob(0.0) -> constrained value is exp(0) = 1.0
     expected_dyn_var = gpjax_params_fixture["epsilon"]["variances"]["obs_noise"]
     assert jnp.isclose(k_eps_dynamic.variance.value, expected_dyn_var)
+    assert isinstance(k_eps_dynamic.variance, gpx.parameters.Parameter)
     assert k_eps_dynamic.active_dims == list(
         range(koh_dataset_fixture.num_variable_params)
     )
@@ -210,22 +211,24 @@ def test_k_epsilon(
     # Case 2: obs_stddev was static
     k_eps_static = minimal_koh_model_static_obs_fixture.k_epsilon(gpjax_params_fixture)
     assert isinstance(k_eps_static, gpx.kernels.White)
-    assert isinstance(k_eps_static.variance, Static)
+    assert not isinstance(k_eps_static.variance, gpx.parameters.Parameter)
     assert jnp.isclose(k_eps_static.variance.value, 0.1**2)
     assert k_eps_static.active_dims == list(
         range(koh_dataset_fixture.num_variable_params)
     )
 
 
-@pytest.mark.parametrize("invalid_obs_stddev", [0.1, jnp.array([0.1]), object()])
-def test_kohmodel_rejects_invalid_obs_stddev_types(
+@pytest.mark.parametrize(
+    "invalid_obs_stddev", [-0.1, jnp.array([-0.1]), jnp.array([0.1, 0.2]), object()]
+)
+def test_kohmodel_rejects_invalid_obs_stddev_values(
     model_parameters_fixture: ModelParameters,
     koh_dataset_fixture: KOHDataset,
     invalid_obs_stddev,
 ):
     with pytest.raises(
         ValueError,
-        match=r"`obs_stddev` must be a `gpx\.parameters\.Static` object or `None`\.",
+        match=r"`obs_stddev` must be",
     ):
         MinimalKOHModel(
             model_parameters=model_parameters_fixture,

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -2,6 +2,7 @@ import jax.tree_util as jtu
 import numpyro.distributions as npd
 import pytest
 from jax import (  # Removed 'config'
+    grad,
     jit,
 )
 from jax import (
@@ -372,3 +373,130 @@ def test_parameter_prior_non_identity_bijector():
     )
     actual_log_prob = prior.log_prob(unconstrained_val)
     assert jnp.isclose(actual_log_prob, expected_log_prob)
+
+
+@pytest.mark.parametrize(
+    ("bad_group", "message"),
+    [
+        (
+            None,
+            r"prior_dict\['eta'\] must be a dictionary of parameter groups",
+        ),
+        (
+            {"variances": {"variance": {"nested": ParameterPrior(npd.Normal(0, 1))}}},
+            r"prior_dict\['eta'\]\['variances'\]\['variance'\] must be a ParameterPrior instance",
+        ),
+    ],
+)
+def test_model_parameters_rejects_malformed_nested_prior_dicts(
+    bad_group, message
+):
+    prior_dict = {
+        "thetas": {"theta": ParameterPrior(npd.Normal(0, 1))},
+        "eta": bad_group,
+        "delta": {"variances": {"variance": ParameterPrior(npd.Normal(0, 1))}},
+    }
+
+    with pytest.raises(ValueError, match=message):
+        ModelParameters(prior_dict)
+
+
+def test_model_parameters_requires_variances_for_each_kernel_group():
+    prior_dict = {
+        "thetas": {"theta": ParameterPrior(npd.Normal(0, 1))},
+        "eta": {"lengthscales": {"lengthscale": ParameterPrior(npd.Normal(0, 1))}},
+        "delta": {"variances": {"variance": ParameterPrior(npd.Normal(0, 1))}},
+    }
+
+    with pytest.raises(
+        KeyError,
+        match=r"prior_dict key 'eta' must contain 'variances' key",
+    ):
+        ModelParameters(prior_dict)
+
+
+@pytest.mark.parametrize(
+    "prior_dict",
+    [
+        {
+            "thetas": {"theta": 0.0},
+            "eta": {"variances": {"variance": ParameterPrior(npd.Normal(0, 1))}},
+            "delta": {"variances": {"variance": ParameterPrior(npd.Normal(0, 1))}},
+        },
+        {
+            "thetas": {"theta": ParameterPrior(npd.Normal(0, 1))},
+            "eta": {"variances": {"variance": 1.0}},
+            "delta": {"variances": {"variance": ParameterPrior(npd.Normal(0, 1))}},
+        },
+    ],
+)
+def test_model_parameters_rejects_non_parameter_prior_leaves(prior_dict):
+    with pytest.raises(ValueError, match="must be a ParameterPrior instance"):
+        ModelParameters(prior_dict)
+
+
+@pytest.mark.parametrize("method_name", ["constrain_sample", "unflatten_sample"])
+@pytest.mark.parametrize("sample_length", [7, 9])
+def test_model_parameters_rejects_wrong_length_flat_samples(
+    model_params: ModelParameters, method_name: str, sample_length: int
+):
+    samples = jnp.zeros(sample_length)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"Flat samples must contain exactly {model_params.n_params} values",
+    ):
+        getattr(model_params, method_name)(samples)
+
+
+def test_parameter_prior_forward_inverse_round_trip_for_constrained_priors():
+    priors = [
+        ParameterPrior(npd.Exponential(rate=1.0)),
+        ParameterPrior(npd.LogNormal(0.0, 1.0)),
+        ParameterPrior(npd.HalfNormal(1.0)),
+    ]
+    unconstrained_values = jnp.array([-1.0, 0.0, 1.25])
+
+    for prior, unconstrained_value in zip(priors, unconstrained_values, strict=True):
+        constrained_value = prior.forward(unconstrained_value)
+        recovered_value = prior.inverse(constrained_value)
+        assert jnp.isfinite(constrained_value)
+        assert jnp.allclose(recovered_value, unconstrained_value)
+
+
+def test_model_parameters_transformed_log_prior_has_finite_correct_gradient():
+    params = ModelParameters(
+        {
+            "thetas": {"theta": ParameterPrior(npd.Normal(0.0, 1.0))},
+            "eta": {
+                "variances": {
+                    "variance": ParameterPrior(npd.Exponential(rate=1.0))
+                }
+            },
+            "delta": {
+                "variances": {"variance": ParameterPrior(npd.LogNormal(0.0, 1.0))}
+            },
+            "epsilon": {
+                "variances": {"noise": ParameterPrior(npd.HalfNormal(1.0))}
+            },
+        }
+    )
+    log_prior = params.get_log_prior_func()
+    unconstrained = jnp.array([0.2, -0.3, 0.4, 0.1])
+
+    # The public function accepts a flat list of scalar leaves. Wrap the
+    # vector input so JAX can differentiate with respect to one flat array.
+    gradient = grad(
+        lambda values: log_prior([values[i] for i in range(params.n_params)])
+    )(unconstrained)
+    expected_gradient = jnp.array(
+        [
+            -0.2,  # delta: LogNormal(0, 1), transformed log density
+            1.0 - jnp.exp(2.0 * -0.3),  # epsilon: HalfNormal(1)
+            1.0 - jnp.exp(0.4),  # eta: Exponential(1)
+            -0.1,  # theta: Normal(0, 1)
+        ]
+    )
+
+    assert jnp.all(jnp.isfinite(gradient))
+    assert jnp.allclose(gradient, expected_gradient, atol=1e-5)


### PR DESCRIPTION
This pull request introduces several important improvements and fixes across the codebase, focusing on enhanced input validation, improved support for rectangular cross-covariance matrices, more robust and user-friendly handling of observation noise, expanded test coverage for edge cases, and updates to dependencies and release automation.

**Key changes include:**

### 1. Improved Input Validation and Error Handling

* Added validation to ensure flat parameter samples have the correct length in `constrain_sample` and `unflatten_sample`, raising clear errors if not (`kohgpjax/parameters.py`). [[1]](diffhunk://#diff-a5648e483eb93aa221cee6fd9a2ba28890a846d1ffa80fe311d6fe3c6d200f31R150) [[2]](diffhunk://#diff-a5648e483eb93aa221cee6fd9a2ba28890a846d1ffa80fe311d6fe3c6d200f31R166) [[3]](diffhunk://#diff-a5648e483eb93aa221cee6fd9a2ba28890a846d1ffa80fe311d6fe3c6d200f31R271-R287)
* Improved validation for prior dictionary structure, ensuring parameter groups are dictionaries (`kohgpjax/parameters.py`).

### 2. Enhanced Observation Noise Handling

* Refactored `KOHModel` to accept observation standard deviation (`obs_stddev`) as a non-negative scalar or one-element array, with robust type and shape checks. The value is now wrapped as a non-trainable variable to prevent accidental optimization (`kohgpjax/kohmodel.py`). [[1]](diffhunk://#diff-ef33c94845e0bfaa633e374eb63472ac7bab55eca051aaf73698180928b17686L32-R32) [[2]](diffhunk://#diff-ef33c94845e0bfaa633e374eb63472ac7bab55eca051aaf73698180928b17686L42-R67)
* Ensured that the likelihood's noise parameter is non-trainable and always set to zero, since noise is handled in the kernel (`kohgpjax/kohmodel.py`).
* Updated the handling of structurally zero `k_epsilon_eta` kernel components to use non-trainable variables unless explicitly set in parameters (`kohgpjax/kohmodel.py`).

### 3. Rectangular Cross-Covariance Support

* Modified the padding logic in `cross_covariance` to support rectangular (N ≠ M) input/output shapes, fixing previous broadcasting issues (`kohgpjax/kernels/computations/kohcomputation.py`). [[1]](diffhunk://#diff-9d65f82c201a88db70f3f5ffeb5dd69b43b2dbe7eb15f68d3901e5a78e834f60R65) [[2]](diffhunk://#diff-9d65f82c201a88db70f3f5ffeb5dd69b43b2dbe7eb15f68d3901e5a78e834f60L74-R75)
* Updated tests to check for correct rectangular cross-covariance behavior and validate the output shape and values (`tests/kernels/test_kohcomputation.py`). [[1]](diffhunk://#diff-bd239e7eb16993a2f843093aa8aa633a629b1680b6f2e7fd2006cdf4894ab93eL189-R199) [[2]](diffhunk://#diff-bd239e7eb16993a2f843093aa8aa633a629b1680b6f2e7fd2006cdf4894ab93eL208-R247)

### 4. Expanded and Improved Test Coverage

* Added comprehensive tests for edge cases in `KOHDataset`, including mismatched input/output rows, zero or one calibration parameters, multiple field/simulation counts, dtype preservation, and pytree round-trip functionality (`tests/test_dataset.py`).
* Ensured all test data uses `float64` for type consistency and enabled double precision in JAX (`tests/test_dataset.py`).
* Added a test to verify that adding observation noise affects the predictive covariance as expected (`tests/test_gps.py`).

### 5. Dependency and Release Automation Updates

* Updated dependencies to support newer versions of `gpjax`, `jax`, `jaxlib`, and `numpy` (`pyproject.toml`).
* Added a GitHub Actions workflow for automated releases to PyPI and GitHub when new tags are pushed (`.github/workflows/release.yml`).
* Bumped package version to `0.4.2` (`kohgpjax/__init__.py`).